### PR TITLE
Modified sed to provide correct IPs for interface and listeners in public IP scenario

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ else
   MY_IP=`ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/'`
 fi
 
-sed -i -e "s/interface=MY_IP/$MY_IP/g" /etc/rtpengine.conf
+sed -i -e "s/interface=MY_IP/interface=$MY_IP/g" /etc/rtpengine.conf
 sed -i -e "s/MY_IP/$LOCAL_IP/g" /etc/rtpengine.conf
 
 if [ "$1" = 'rtpengine' ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,8 @@ else
   MY_IP=`ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/'`
 fi
 
-sed -i -e "s/MY_IP/$MY_IP/g" /etc/rtpengine.conf
+sed -i -e "s/interface=MY_IP/$MY_IP/g" /etc/rtpengine.conf
+sed -i -e "s/MY_IP/$LOCAL_IP/g" /etc/rtpengine.conf
 
 if [ "$1" = 'rtpengine' ]; then
   shift


### PR DESCRIPTION
Previous build would throw:

CRIT: [core] Fatal error: Invalid IP or port '!1.2.3.4:22222' (--listen-ng)

If you had a public IP of 1.2.3.4 and private IP of 192.168.1.1, as it would insert 192.168.1.1!1.2.3.4 into the `interface=` line in the config (correct) but also into the listeners (incorrect). This uses the ! style on only the `interface=` line.