### PR TITLE
Use LOCAL_IP even if PUBLIC_IP is empty

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,6 +30,8 @@ esac
 
 if [ -n "$PUBLIC_IP" ]; then
   MY_IP="$LOCAL_IP"!"$PUBLIC_IP"
+elif [ -n "$LOCAL_IP" ]; then
+  MY_IP="$LOCAL_IP"
 else
   MY_IP=`ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/'`
 fi


### PR DESCRIPTION
Also allows passing LOCAL_IP as an env var, when the address discovery heuristic may fail (for example, when using host network).