### PR TITLE
rtpengine with alpine base image

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 PATH=/usr/local/bin:$PATH
@@ -68,7 +68,7 @@ if [ "$1" = 'rtpengine' ]; then
   --interface ${PRIVATE_INTERFACE} --interface ${PUBLIC_INTERFACE} \
   --port-min ${RTP_START_PORT} --port-max ${RTP_END_PORT} \
   --log-level ${LOGLEVEL} --port-min ${RTP_START_PORT} --port-max ${RTP_END_PORT} \
-  --listen-ng=22222 --listen-http=8080 --listen-udp=12222 \
+  --listen-ng=22222 --listen-http=127.0.0.1:8080 --listen-udp=12222 \
   --dtmf-log-dest=127.0.0.1:22223 \
   --listen-cli=127.0.0.1:9900 \
   --pidfile /var/run/rtpengine.pid \


### PR DESCRIPTION
Moved base image from Debian 12 to Alpine. The benefits are:
- faster build
- smaller image
- less vulnerabilities
